### PR TITLE
feat: add ParseResult JSON schema output

### DIFF
--- a/src/parsemux/cli/main.py
+++ b/src/parsemux/cli/main.py
@@ -216,8 +216,15 @@ def detect(
 @app.command()
 def schema(
     command: Optional[str] = typer.Argument(None, help="Command name (omit for all)"),
+    output_schema: bool = typer.Option(False, "--output-schema", help="Print the ParseResult JSON Schema"),
 ) -> None:
     """Show machine-readable schema for CLI commands (for AI agents)."""
+    if output_schema:
+        from parsemux.core.models import ParseResult
+
+        typer.echo(json.dumps(ParseResult.model_json_schema(), indent=2))
+        return
+
     schemas = {
         "parse": {
             "description": "Parse a document and extract structured content",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import json
+
+from typer.testing import CliRunner
+
+from parsemux import __version__
+from parsemux.cli.main import app
+
+runner = CliRunner()
+
+
+def test_version_command_outputs_version() -> None:
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == f"parsemux {__version__}"
+
+
+def test_version_flag_outputs_version() -> None:
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == f"parsemux {__version__}"
+
+
+def test_schema_output_schema_prints_parse_result_schema() -> None:
+    result = runner.invoke(app, ["schema", "--output-schema"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["title"] == "ParseResult"
+    assert "properties" in payload


### PR DESCRIPTION
Adds parsemux schema --output-schema to print the ParseResult Pydantic JSON Schema. Also adds a CLI test for the new output.

Closes #12